### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/src/components/Ad402Provider.tsx
+++ b/src/components/Ad402Provider.tsx
@@ -17,6 +17,7 @@ export const Ad402Provider: React.FC<{
   useEffect(() => {
     if (!config.websiteId) {
       setError({
+        type: 'UNKNOWN_ERROR',
         code: 'MISSING_WEBSITE_ID',
         message: 'websiteId is required in Ad402Config'
       });
@@ -25,6 +26,7 @@ export const Ad402Provider: React.FC<{
 
     if (!config.walletAddress) {
       setError({
+        type: 'UNKNOWN_ERROR',
         code: 'MISSING_WALLET_ADDRESS',
         message: 'walletAddress is required in Ad402Config'
       });
@@ -34,6 +36,7 @@ export const Ad402Provider: React.FC<{
     // Basic wallet address validation (Ethereum address format)
     if (!/^0x[a-fA-F0-9]{40}$/.test(config.walletAddress)) {
       setError({
+        type: 'UNKNOWN_ERROR',
         code: 'INVALID_WALLET_ADDRESS',
         message: 'walletAddress must be a valid Ethereum address (0x...)'
       });

--- a/src/components/__tests__/Ad402Slot.test.tsx
+++ b/src/components/__tests__/Ad402Slot.test.tsx
@@ -59,7 +59,7 @@ describe('Ad402Slot Error Handling', () => {
             } as any)
         );
 
-        render(<TestWrapper><Ad402Slot slotId="slot-1" /></TestWrapper>);
+        render(<TestWrapper><Ad402Slot slotId="slot-1" size="banner" price="0.25" /></TestWrapper>);
 
         expect(screen.getByText('Loading...')).toBeInTheDocument();
     });
@@ -77,7 +77,7 @@ describe('Ad402Slot Error Handling', () => {
         );
 
         await act(async () => {
-            render(<TestWrapper><Ad402Slot slotId="slot-1" /></TestWrapper>);
+            render(<TestWrapper><Ad402Slot slotId="slot-1" size="banner" price="0.25" /></TestWrapper>);
         });
 
         expect(screen.getByText('Please check your internet connection.')).toBeInTheDocument();
@@ -95,7 +95,7 @@ describe('Ad402Slot Error Handling', () => {
         );
 
         await act(async () => {
-            render(<TestWrapper><Ad402Slot slotId="slot-1" /></TestWrapper>);
+            render(<TestWrapper><Ad402Slot slotId="slot-1" size="banner" price="0.25" /></TestWrapper>);
         });
 
         expect(screen.getByText("We're having trouble loading this ad.")).toBeInTheDocument();
@@ -116,7 +116,7 @@ describe('Ad402Slot Error Handling', () => {
         );
 
         await act(async () => {
-            render(<TestWrapper><Ad402Slot slotId="slot-1" /></TestWrapper>);
+            render(<TestWrapper><Ad402Slot slotId="slot-1" size="banner" price="0.25" /></TestWrapper>);
         });
 
         const retryButton = screen.getByRole('button', { name: /Retry/i });


### PR DESCRIPTION
- Add missing 'type' property to Ad402Error objects in Ad402Provider.tsx
- Add required 'size' and 'price' props to Ad402Slot test components

Fixes 7 TypeScript compilation errors:
- 3 errors: Missing 'type' field in Ad402Error interface compliance
- 4 errors: Missing required props in test components